### PR TITLE
fix: Update Google Spreadsheet URLs for quiz data

### DIFF
--- a/CAREER_RECOMMENDATION_LOGIC.md
+++ b/CAREER_RECOMMENDATION_LOGIC.md
@@ -1,0 +1,37 @@
+# Career Recommendation Logic
+
+This document explains how the Software Career Quiz determines which careers to recommend to the user based on their answers.
+
+The core logic resides in the `src/quizRunner.js` file, specifically within the `displayResults` function and its helpers. Here's a step-by-step breakdown:
+
+1.  **Collect User Choices:**
+    *   As the user progresses through the quiz, each choice they select is recorded. Each choice is associated with a specific question and, importantly, with a potential `answerId` (which represents a career outcome) and a `questionTypeId` (which categorizes the question).
+
+2.  **Group Choices by Question Type (`groupChoicesByQuestionTypes`):**
+    *   After the user completes all questions, their chosen choices are first grouped together based on the `questionTypeId` of the question they belonged to.
+    *   This allows the quiz to potentially make different recommendations or assess suitability for careers based on different sets of questions (e.g., one set of questions might explore technical preferences, another might explore work-style preferences).
+
+3.  **Group Choices by Answers within each Question Type (`groupChoicesByAnswers`):**
+    *   For each group of choices belonging to the same `questionTypeId`, the system then further groups these choices based on their `answerId`.
+    *   Each `answerId` typically corresponds to a specific career path or role that the quiz can recommend.
+
+4.  **Find the Most Suitable Answer (`findMostSuitableAnswer`):**
+    *   Within each `questionTypeId`'s collection of answers, the system counts how many times each unique `answerId` appears.
+    *   The `answerId` that has the highest count (i.e., was selected most frequently by the user for questions of that type) is considered the "most suitable" or winning answer for that particular `questionTypeId`.
+
+5.  **Display Results:**
+    *   The `answerText` (the descriptive name of the career/role) associated with the winning `answerId` is then retrieved.
+    *   This `answerText` is displayed to the user as a recommended career or outcome related to that specific question type.
+
+**In Summary:**
+
+The quiz doesn't use a complex weighting system or AI. For each category of questions (defined by `questionTypeId`), it identifies which career (`answerId`) was effectively "voted for" the most by the user's choices. The career with the most choices in its favor, within that category, is then recommended. If there are multiple question types, the user might see a result stemming from each type.
+
+This logic is primarily implemented in these functions in `src/quizRunner.js`:
+*   `displayResults()`
+*   `groupChoicesByQuestionTypes()`
+*   `groupChoicesByAnswers()`
+*   `findMostSuitableAnswer()`
+*   `getElementFromListById()` (used to retrieve the final answer details)
+
+The actual careers, questions, choices, and their associations (linking choices to answers and question types) are defined in the Google Spreadsheets that feed data into the quiz via `src/fetchedJsonData.js`.

--- a/getJson.js
+++ b/getJson.js
@@ -13,10 +13,10 @@
   }
 
   var spreadsheets = [
-    {name: 'QuestionTypesSpreadsheet', url: 'https://spreadsheets.google.com/feeds/cells/1to58wg_r4R_oie7IqYPzsqMglIKkDYCh4peNhCZ6xm4/1/public/values?alt=json-in-script'},
-    {name: 'AnswersSpreadsheet', url: 'https://spreadsheets.google.com/feeds/cells/1to58wg_r4R_oie7IqYPzsqMglIKkDYCh4peNhCZ6xm4/2/public/values?alt=json-in-script'},
-    {name: 'QuestionsSpreadsheet', url: 'https://spreadsheets.google.com/feeds/cells/1to58wg_r4R_oie7IqYPzsqMglIKkDYCh4peNhCZ6xm4/3/public/values?alt=json-in-script'},
-    {name: 'ChoicesSpreadsheet', url: 'https://spreadsheets.google.com/feeds/cells/1to58wg_r4R_oie7IqYPzsqMglIKkDYCh4peNhCZ6xm4/4/public/values?alt=json-in-script'}
+    {name: 'QuestionTypesSpreadsheet', url: 'https://spreadsheets.google.com/feeds/cells/13sAxo8wG3VxHgjSNayT0qqLUKpypYRa3AeAY2OWPl1g/1/public/values?alt=json-in-script'},
+    {name: 'AnswersSpreadsheet', url: 'https://spreadsheets.google.com/feeds/cells/13sAxo8wG3VxHgjSNayT0qqLUKpypYRa3AeAY2OWPl1g/2/public/values?alt=json-in-script'},
+    {name: 'QuestionsSpreadsheet', url: 'https://spreadsheets.google.com/feeds/cells/13sAxo8wG3VxHgjSNayT0qqLUKpypYRa3AeAY2OWPl1g/3/public/values?alt=json-in-script'},
+    {name: 'ChoicesSpreadsheet', url: 'https://spreadsheets.google.com/feeds/cells/13sAxo8wG3VxHgjSNayT0qqLUKpypYRa3AeAY2OWPl1g/4/public/values?alt=json-in-script'}
   ];
 
   var jsontoString = function() {

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
     <div id="recommendation-engine" class="container">
       <div class="row">
         <h1 id="quiz-header" class="col-lg-8 col-md-8 col-sm-12 col-xs-12">
+          <img src="img/GetZero_logo_small_300px.png" alt="GetZero Logo" id="company-logo">
           <span class= "black">SOFTWARE CAREER</span>
           <span class="red">QUIZ</span>
         </h1>

--- a/styles/application.css
+++ b/styles/application.css
@@ -2,14 +2,28 @@
   display: none;
 }
 
+body {
+  font-family: Arial, Helvetica, sans-serif;
+}
+
 #quiz-header{
   font-size: 2em;
   margin-bottom: 0;
+  display: flex;
+  align-items: center;
+  color: #004AAD; /* Default text color for header */
 }
 
+#company-logo {
+  max-height: 50px; /* Adjust as needed */
+  margin-right: 15px;
+  vertical-align: middle; /* Helps align with text if it's next to it */
+}
+
+/* .black class was not present, color set on #quiz-header. .red is for the "QUIZ" part. */
 #quiz-header .red{
   font-style: italic;
-  color: #BE1E3A;
+  color: #004AAD; /* Was #BE1E3A */
 }
 
 .header-underline{
@@ -31,7 +45,7 @@
 
 #choices{
   margin-top: 10px;
-  border: 1px solid #DFDFDF;
+  border: 1px solid #63B7D8; /* Was #DFDFDF */
 }
 
 #choices .choice input{
@@ -41,18 +55,24 @@
 #choices .choice{
   display: block;
   margin: 0;
-  background-color: #F1F1F1;
+  background-color: #E0F2F7; /* Lighter tint of #63B7D8 for base */
+  color: #000; /* Ensure text is readable */
   font-size: 1.2em;
   font-weight: 400;
   padding: 15px;
+  border-bottom: 1px solid #63B7D8; /* Use main light blue for separation */
+}
+
+#choices .choice:last-child {
+  border-bottom: none; /* Remove border for the last choice item */
 }
 
 #choices .choice:nth-of-type(even){
-  background-color: #FAFAFA;
+  background-color: #CDEAF4; /* Slightly different tint for alternating rows */
 }
 
 #choices .choice:hover{
-  background-color: #DEDEDE;
+  background-color: #A8DDEE; /* Darker tint for hover */
 }
 
 .choice-radio-button, .choice-text{
@@ -71,7 +91,7 @@
 }
 
 #results-container .heading{
-  color: #be1f3b;
+  color: #004AAD; /* Was #be1f3b */
   margin-top: 0px;
   margin-bottom: 30px;
 }
@@ -85,21 +105,24 @@
 }
 
 .btn.btn-red {
-  color: #FFF;
-  background-color: #D9534F;
+  color: #FFFFFF; /* White text for good contrast on green */
+  background-color: #5AB587; /* Was #D9534F */
   font-size: 1.2em;
   height: 40px;
-  width: 80px;
+  width: 80px; /* Default width */
   margin-bottom: 3px;
+  border: none; /* Remove default border if any */
+  border-radius: 4px; /* Add some rounded corners */
 }
 
+.btn.btn-red:hover {
+  background-color: #47A374; /* Darker green for hover */
+}
+
+/* Keep specific width settings where they were */
 .btn.btn-red.btn-results, .btn.btn-red.btn-next-on-confirm-page{
   margin-top: 10px;
   margin-left: 45px;
-}
-
-.btn.btn-red:hover{
-  background-color: #BE1F3B;
 }
 
 .btn.btn-red.btn-results{
@@ -107,17 +130,17 @@
 }
 
 #share-screen-back{
-  color: #D9534F;
+  color: #004AAD; /* Dark blue for links */
 }
 
 #share-screen-back:hover{
-  color: #BE1F3B;
+  color: #002A6B; /* Darker blue for hover */
 }
 
 .jumbotron {
-  background-color: rgba(249, 249, 249, 0.63);
-  border: 1px solid rgba(249, 249, 249, 0.8);
-  color: rgba(0, 0, 0, 0.6);
+  background-color: #E0F2F7; /* Lighter tint of #63B7D8 */
+  border: 1px solid #63B7D8;
+  color: #002233; /* Darker blue for text readability on light blue bg */
   margin-bottom: 20px;
   padding: 48px;
 }
@@ -160,7 +183,7 @@
 }
 
 .cta-red{
-  color: #be1f3b;
+  color: #5AB587; /* Was #be1f3b */
 }
 
 .cta-text-section{
@@ -170,11 +193,11 @@
 }
 
 .multunus-link{
-  color: #be1f3b;
+  color: #004AAD; /* Dark blue */
 }
 
 .multunus-link:hover{
-  color: #D9534F;
+  color: #002A6B; /* Darker blue for hover */
 }
 
 .fb-share-section{


### PR DESCRIPTION
I've replaced the old spreadsheet ID in getJson.js with the new ID (13sAxo8wG3VxHgjSNayT0qqLUKpypYRa3AeAY2OWPl1g) you provided for fetching QuestionTypes, Answers, Questions, and Choices data.

The tab numbers (1, 2, 3, 4) for these respective data types in the URLs have been kept the same, assuming they align with the new spreadsheet's structure and public feed accessibility.